### PR TITLE
docs: comprehensive documentation audit and update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,94 @@
+# rag-suite
+
+Modular, corpus-preferring RAG stack. Documents go in, grounded answers come out, hallucinations get caught.
+
+## Components
+
+| Repo | What it does | Status |
+|------|-------------|--------|
+| ragpipe | RAG proxy — semantic routing, retrieval, reranking, citation validation, grounding classification | Production |
+| ragstuffer | Document ingestion — polls Google Drive, git repos, and web URLs; extracts, chunks, embeds, indexes | Production |
+| ragprobe | Adversarial testing — 66+ tests across 13 categories for grounding quality, citation accuracy, and safety | Production |
+| ragwatch | Observability — scrapes Prometheus metrics from ragpipe and ragstuffer, exposes /metrics and /metrics/summary | Production |
+| ragdeck | Admin UI — single-pane management for collections, ingest, query log, probe runs, and metrics | Scaffold (health endpoint only) |
+| framework-ai-stack | Reference deployment — full local stack on Fedora with Podman quadlets, auto-tuning, and systemd | Production |
+
+## Architecture overview
+
+```
+Client → Open WebUI (:3000) → LiteLLM (:4000) → ragpipe (:8090)
+                                                    │
+                                    ┌───────────────┴───────────────┐
+                                    │   Semantic Router (cosine sim) │
+                                    └───────────────┬───────────────┘
+                              ┌───────────────┼───────────────┐
+                              ▼               ▼               ▼
+                        personnel          nato              mpep
+                        (Qdrant)         (Qdrant)         (Qdrant)
+                              │               │               │
+                              └───────────────┼───────────────┘
+                                            ▼
+                                     Postgres (:5432)
+                                chunks + titles + query_log
+                                            │
+                          ┌─────────────────┼─────────────────┐
+                          ▼                 ▼                 ▼
+                    ragstuffer          ragwatch           ragdeck
+                    (:8091)            (:9090)            (:8095)
+                    (ingestion)        (metrics)          (admin UI)
+```
+
+### Semantic routing
+
+ragpipe classifies queries using cosine similarity against pre-embedded route
+examples and routes to the appropriate Qdrant collection. Each collection
+(personnel, nato, mpep) is a separate retrieval domain.
+
+Routes are hot-reloadable without restarting ragpipe:
+```bash
+curl -X POST http://localhost:8090/admin/reload-routes \
+  -H "Authorization: Bearer $RAGPIPE_ADMIN_TOKEN"
+```
+
+### Title extraction pipeline
+
+1. ragstuffer extracts titles per source type (PDF metadata, Markdown headings, etc.)
+2. Titles stored in Postgres `chunks` table alongside chunk text
+3. ragpipe surfaces titles in `rag_metadata.cited_chunks[].title` at query time
+
+### Query log partitioning
+
+`query_log` table is partitioned by day in Postgres:
+```
+query_log_20260405
+query_log_20260406
+query_log_20260407
+...
+```
+
+This enables efficient time-series queries and archival.
+
+## Shared Postgres schema
+
+```
+chunks         — Document chunk text + title (created by ragstuffer, read by ragpipe)
+collections    — Collection registry with source_type
+query_log      — Partitioned by day, written by ragpipe
+LiteLLM_*      — LiteLLM proxy state and guardrail metrics
+```
+
+## GPU requirements
+
+- **System**: AMD Ryzen AI Max+ 395 (gfx1151) with ROCm 7.x
+- **GPU provider**: MIGraphXExecutionProvider only — ROCMExecutionProvider is ABI-incompatible with ROCm 7.x
+- **Required env**: `HSA_OVERRIDE_GFX_VERSION=11.5.1`
+- **⚠️ Startup time**: ragpipe takes ~3 minutes on first query after startup while MIGraphX compiles the inference graph
+
+## Hot-reload endpoints
+
+No need to restart ragpipe for configuration changes:
+- `POST /admin/reload-prompt` — reload system prompt from file
+- `POST /admin/reload-routes` — reload semantic routing config
+
+Routes and system prompt are mounted from the host at `~/.config/ragpipe/routes.yaml`
+and `~/.config/ragpipe/system-prompt.txt`.

--- a/README.md
+++ b/README.md
@@ -4,14 +4,61 @@ A modular, corpus-preferring RAG stack. Documents go in, grounded answers come o
 
 ## Components
 
-| Repo | What it does |
-|------|-------------|
-| [ragpipe](https://github.com/aclater/ragpipe) | RAG proxy — semantic routing, retrieval, reranking, citation validation, grounding classification |
-| [ragstuffer](https://github.com/aclater/ragstuffer) | Document ingestion — polls Google Drive, git repos, and web URLs; extracts, chunks, embeds, indexes |
-| [ragprobe](https://github.com/aclater/ragprobe) | Adversarial testing — 66+ tests across 13 categories for grounding quality, citation accuracy, and safety |
-| [ragwatch](https://github.com/aclater/ragwatch) | Observability — Prometheus + Grafana metrics from ragpipe, ragstuffer, and ragprobe |
-| [ragdeck](https://github.com/aclater/ragdeck) | Admin UI — single-pane management for collections, ingest, query log, probe runs, and metrics |
-| [framework-ai-stack](https://github.com/aclater/framework-ai-stack) | Reference deployment — full local stack on Fedora with Podman quadlets, auto-tuning, and systemd |
+| Repo | What it does | Status |
+|------|-------------|--------|
+| [ragpipe](https://github.com/aclater/ragpipe) | RAG proxy — semantic routing, retrieval, reranking, citation validation, grounding classification | Production |
+| [ragstuffer](https://github.com/aclater/ragstuffer) | Document ingestion — polls Google Drive, git repos, and web URLs; extracts, chunks, embeds, indexes | Production |
+| [ragprobe](https://github.com/aclater/ragprobe) | Adversarial testing — 66+ tests across 13 categories for grounding quality, citation accuracy, and safety | Production |
+| [ragwatch](https://github.com/aclater/ragwatch) | Observability — scrapes Prometheus metrics from ragpipe and ragstuffer, exposes /metrics and /metrics/summary | Production |
+| [ragdeck](https://github.com/aclater/ragdeck) | Admin UI — single-pane management for collections, ingest, query log, probe runs, and metrics | Scaffold (health endpoint only) |
+| [framework-ai-stack](https://github.com/aclater/framework-ai-stack) | Reference deployment — full local stack on Fedora with Podman quadlets, auto-tuning, and systemd | Production |
+| [rag-suite](https://github.com/aclater/rag-suite) | This repo — component documentation and shared Postgres migrations | Documentation |
+
+## Architecture
+
+rag-suite implements a **semantic router** that classifies incoming queries and routes them to different Qdrant collections (personnel, nato, mpep, documents), each with isolated retrieval pipelines.
+
+```
+Client → Open WebUI (:3000) → LiteLLM (:4000) → ragpipe (:8090)
+                                                    │
+                                    ┌───────────────┴───────────────┐
+                                    │   Semantic Router (cosine sim) │
+                                    └───────────────┬───────────────┘
+                              ┌───────────────┼───────────────┐
+                              ▼               ▼               ▼
+                        personnel          nato              mpep
+                        (Qdrant)         (Qdrant)         (Qdrant)
+                              │               │               │
+                              └───────────────┼───────────────┘
+                                            ▼
+                                     Postgres (:5432)
+                                chunks + titles + query_log
+                                            │
+                          ┌─────────────────┼─────────────────┐
+                          ▼                 ▼                 ▼
+                    ragstuffer          ragwatch           ragdeck
+                    (:8091)            (:9090)            (:8095)
+                    (ingestion)        (metrics)          (admin UI)
+```
+
+### Data flows
+
+- **Queries**: Client → Open WebUI → LiteLLM → ragpipe → Qdrant (per-route collection) → Postgres (chunk hydration with titles) → ragpipe → LLM → response + rag_metadata
+- **Ingestion**: Google Drive / git / web → ragstuffer → Qdrant (vectors) + Postgres (chunks + titles)
+- **Metrics**: ragpipe → ragwatch (:9090) ← ragstuffer ← Prometheus scraping
+- **Query log**: ragpipe → Postgres `query_log` (partitioned by day)
+- **Admin**: ragdeck → all services via API
+
+### Title extraction
+
+ragstuffer extracts titles per source type and stores them alongside chunk metadata in Postgres. ragpipe surfaces titles in `rag_metadata.cited_chunks[].title`:
+
+| Source | Title source |
+|--------|-------------|
+| PDF | PDF metadata Title, or filename |
+| DOCX/PPTX | Office document title, or filename |
+| git/Markdown | First `# Heading` in file, or filename |
+| Web | `<title>` tag, or URL path |
 
 ## How they fit together
 
@@ -24,7 +71,9 @@ A modular, corpus-preferring RAG stack. Documents go in, grounded answers come o
 - **Grounding classification** — every response is classified as `corpus`, `general`, or `mixed`, available in `rag_metadata` for downstream consumers.
 - **Text-free audit logging** — grounding decisions are logged without echoing document text or user queries, safe for compliance-sensitive environments.
 - **Separation of concerns** — ingestion, retrieval, inference, and testing are independent services. Swap any component without touching the others.
-- **Semantic routing** — ragpipe classifies queries and routes them to different LLMs, vector collections, and document stores per routing domain. A medical corpus and a finance corpus can share the same endpoint with separate retrieval pipelines.
+- **Semantic routing** — ragpipe classifies queries and routes them to different Qdrant collections, LLMs, and document stores per routing domain. A medical corpus and a finance corpus can share the same endpoint with separate retrieval pipelines.
+- **Multi-collection isolation** — each collection (personnel, nato, mpep) is a separate retrieval domain with its own vectors, chunks, and titles.
+- **Hot-reload configuration** — system prompt and routes can be reloaded without restarting ragpipe via admin endpoints.
 
 ## Quick start
 
@@ -36,7 +85,7 @@ cd framework-ai-stack
 ./llm-stack.sh setup    # auto-tunes for your hardware, pulls model, starts services
 ```
 
-This brings up Postgres, Qdrant, ramalama (model serving), ragpipe, LiteLLM, Open WebUI, and ragstuffer as rootless Podman containers managed by systemd quadlets.
+This brings up Postgres, Qdrant, ramalama (model serving), ragpipe, LiteLLM, Open WebUI, ragstuffer, and ragwatch as rootless Podman containers managed by systemd quadlets.
 
 To run the components individually, see each repo's README.
 
@@ -61,9 +110,10 @@ all services. See [migrations/README.md](migrations/README.md) for details.
 
 | Table | Purpose | Owner |
 |---|---|---|
-| `chunks` | Document chunk text (created by ragstuffer, read by ragpipe) | ragstuffer / ragpipe |
-| `collections` | Authoritative collection registry | All services |
-| `query_log` | Query observability, partitioned by day | ragpipe (writes) |
+| `chunks` | Document chunk text + title metadata (created by ragstuffer, read by ragpipe) | ragstuffer / ragpipe |
+| `collections` | Authoritative collection registry with source_type | All services |
+| `query_log` | Query observability, partitioned by day (20260405, 20260406, ...) | ragpipe (writes) |
+| `LiteLLM_*` | LiteLLM proxy state and guardrail metrics | litellm |
 
 ### Running migrations
 
@@ -75,13 +125,15 @@ bash migrations/run_migrations.sh
 
 ## Tech stack
 
-- **Runtime**: Python (ragpipe, ragstuffer), Node.js (ragprobe), Bash (framework-ai-stack)
-- **Embedding**: ONNX Runtime (bge-base-en-v1.5), no fastembed — 708 MB RSS
-- **Reranking**: ONNX Runtime (MiniLM-L-6-v2 cross-encoder)
-- **Vector DB**: Qdrant with int8 scalar quantization (reference payloads only)
-- **Document store**: PostgreSQL (full chunk text, asyncpg pool)
+- **Runtime**: Python (ragpipe, ragstuffer, ragwatch), Node.js (ragprobe), Bash (framework-ai-stack)
+- **Embedding**: ONNX Runtime (gte-modernbert-base), no fastembed — 708 MB RSS
+- **Reranking**: ONNX Runtime (MiniLM-L-6-v2 cross-encoder, CPU-only on gfx1151)
+- **Vector DB**: Qdrant v1.17.1 with int8 scalar quantization (reference payloads only)
+- **Document store**: PostgreSQL 16 (full chunk text + titles, asyncpg pool)
+- **GPU inference**: MIGraphXExecutionProvider (AMD ROCm 7.x, gfx1151) — ~3 min startup
 - **Containers**: Rootless Podman, systemd quadlets, UBI base images, SELinux enforcing
 - **Testing**: promptfoo with custom Python assertions, pytest
+- **Observability**: Prometheus metrics from ragpipe/ragstuffer, aggregated by ragwatch
 
 ## License
 

--- a/architecture.svg
+++ b/architecture.svg
@@ -1,234 +1,302 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 740" font-family="system-ui, -apple-system, sans-serif" font-size="13">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" font-family="system-ui, -apple-system, sans-serif" font-size="12">
+  <title>rag-suite architecture</title>
+  <desc>rag-suite modular RAG stack architecture diagram showing services, ports, and data flows</desc>
+
   <style>
     @media (prefers-color-scheme: dark) {
-      .bg { fill: #1a1a2e; }
-      .box { fill: #16213e; stroke: #e2e8f0; }
-      .box-ragpipe { fill: #1a365d; stroke: #63b3ed; }
-      .box-ragstuffer { fill: #1c3d2a; stroke: #68d391; }
-      .box-ragprobe { fill: #3d1c2a; stroke: #f687b3; }
-      .box-ragwatch { fill: #3d2e1a; stroke: #f6ad55; }
-      .box-ragdeck { fill: #1a2e3d; stroke: #4fd1c5; }
-      .box-stack { fill: #2d2d1c; stroke: #ecc94b; }
-      .box-external { fill: #1c1c1c; stroke: #718096; }
-      .box-store { fill: #1e2a3a; stroke: #a0aec0; }
-      .text { fill: #e2e8f0; }
-      .text-dim { fill: #a0aec0; }
-      .text-accent { fill: #63b3ed; }
-      .text-green { fill: #68d391; }
-      .text-pink { fill: #f687b3; }
-      .text-orange { fill: #f6ad55; }
-      .text-teal { fill: #4fd1c5; }
-      .text-yellow { fill: #ecc94b; }
-      .arrow { stroke: #63b3ed; fill: #63b3ed; }
-      .arrow-green { stroke: #68d391; fill: #68d391; }
-      .arrow-pink { stroke: #f687b3; fill: #f687b3; }
-      .arrow-orange { stroke: #f6ad55; fill: #f6ad55; }
-      .arrow-teal { stroke: #4fd1c5; fill: #4fd1c5; }
-      .arrow-dim { stroke: #718096; fill: #718096; }
-      .label-bg { fill: #2d3748; }
-      .region { fill: none; stroke: #4a5568; stroke-dasharray: 6,3; }
+      .bg { fill: #0f1419; }
+      .box-ingestion { fill: #1a2f4a; stroke: #4da6ff; }
+      .box-inference { fill: #1a3a2f; stroke: #4dff88; }
+      .box-storage { fill: #3a2f1a; stroke: #ffb84d; }
+      .box-observability { fill: #2f1a3a; stroke: #b84dff; }
+      .box-admin { fill: #2f3a1a; stroke: #8dff4d; }
+      .box-client { fill: #1a1a2a; stroke: #888899; }
+      .text { fill: #e8eaed; }
+      .text-dim { fill: #9aa0a6; }
+      .text-ingestion { fill: #4da6ff; }
+      .text-inference { fill: #4dff88; }
+      .text-storage { fill: #ffb84d; }
+      .text-observability { fill: #b84dff; }
+      .text-admin { fill: #8dff4d; }
+      .text-client { fill: #aaaabc; }
+      .arrow-ingestion { stroke: #4da6ff; fill: #4da6ff; }
+      .arrow-inference { stroke: #4dff88; fill: #4dff88; }
+      .arrow-storage { stroke: #ffb84d; fill: #ffb84d; }
+      .arrow-observability { stroke: #b84dff; fill: #b84dff; }
+      .arrow-admin { stroke: #8dff4d; fill: #8dff4d; }
+      .arrow-client { stroke: #888899; fill: #888899; }
+      .label-bg { fill: #1e2832; }
+      .legend-bg { fill: #1a1f26; stroke: #3a4550; }
     }
     @media (prefers-color-scheme: light) {
       .bg { fill: #ffffff; }
-      .box { fill: #f7fafc; stroke: #2d3748; }
-      .box-ragpipe { fill: #ebf8ff; stroke: #3182ce; }
-      .box-ragstuffer { fill: #f0fff4; stroke: #38a169; }
-      .box-ragprobe { fill: #fff5f7; stroke: #d53f8c; }
-      .box-ragwatch { fill: #fffaf0; stroke: #dd6b20; }
-      .box-ragdeck { fill: #e6fffa; stroke: #319795; }
-      .box-stack { fill: #fffff0; stroke: #b7791f; }
-      .box-external { fill: #f9f9f9; stroke: #a0aec0; }
-      .box-store { fill: #edf2f7; stroke: #718096; }
-      .text { fill: #1a202c; }
-      .text-dim { fill: #718096; }
-      .text-accent { fill: #2b6cb0; }
-      .text-green { fill: #276749; }
-      .text-pink { fill: #b83280; }
-      .text-orange { fill: #c05621; }
-      .text-teal { fill: #285e61; }
-      .text-yellow { fill: #975a16; }
-      .arrow { stroke: #3182ce; fill: #3182ce; }
-      .arrow-green { stroke: #38a169; fill: #38a169; }
-      .arrow-pink { stroke: #d53f8c; fill: #d53f8c; }
-      .arrow-orange { stroke: #dd6b20; fill: #dd6b20; }
-      .arrow-teal { stroke: #319795; fill: #319795; }
-      .arrow-dim { stroke: #a0aec0; fill: #a0aec0; }
-      .label-bg { fill: #edf2f7; }
-      .region { fill: none; stroke: #cbd5e0; stroke-dasharray: 6,3; }
+      .box-ingestion { fill: #e8f4ff; stroke: #0066cc; }
+      .box-inference { fill: #e8fff4; stroke: #00aa44; }
+      .box-storage { fill: #fff4e8; stroke: #cc6600; }
+      .box-observability { fill: #f4e8ff; stroke: #8800cc; }
+      .box-admin { fill: #f4ffe8; stroke: #558800; }
+      .box-client { fill: #f0f0f5; stroke: #555566; }
+      .text { fill: #1a1a1a; }
+      .text-dim { fill: #666666; }
+      .text-ingestion { fill: #0066cc; }
+      .text-inference { fill: #00aa44; }
+      .text-storage { fill: #cc6600; }
+      .text-observability { fill: #8800cc; }
+      .text-admin { fill: #558800; }
+      .text-client { fill: #555566; }
+      .arrow-ingestion { stroke: #0066cc; fill: #0066cc; }
+      .arrow-inference { stroke: #00aa44; fill: #00aa44; }
+      .arrow-storage { stroke: #cc6600; fill: #cc6600; }
+      .arrow-observability { stroke: #8800cc; fill: #8800cc; }
+      .arrow-admin { stroke: #558800; fill: #558800; }
+      .arrow-client { stroke: #555566; fill: #555566; }
+      .label-bg { fill: #f0f0f0; }
+      .legend-bg { fill: #f8f8f8; stroke: #cccccc; }
     }
   </style>
   <defs>
-    <marker id="ah" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <polygon points="0 0, 8 3, 0 6" class="arrow"/>
+    <marker id="ai" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" class="arrow-ingestion"/>
     </marker>
-    <marker id="ahg" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <polygon points="0 0, 8 3, 0 6" class="arrow-green"/>
+    <marker id="aii" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" class="arrow-inference"/>
     </marker>
-    <marker id="ahp" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <polygon points="0 0, 8 3, 0 6" class="arrow-pink"/>
+    <marker id="as" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" class="arrow-storage"/>
     </marker>
-    <marker id="aho" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <polygon points="0 0, 8 3, 0 6" class="arrow-orange"/>
+    <marker id="ao" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" class="arrow-observability"/>
     </marker>
-    <marker id="aht" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <polygon points="0 0, 8 3, 0 6" class="arrow-teal"/>
+    <marker id="aa" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" class="arrow-admin"/>
     </marker>
-    <marker id="ahd" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <polygon points="0 0, 8 3, 0 6" class="arrow-dim"/>
+    <marker id="ac" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" class="arrow-client"/>
     </marker>
   </defs>
 
-  <rect width="960" height="740" class="bg" rx="8"/>
+  <rect width="1200" height="800" class="bg"/>
 
   <!-- Title -->
-  <text x="480" y="32" text-anchor="middle" font-size="18" font-weight="bold" class="text">RAG Suite</text>
-  <text x="480" y="50" text-anchor="middle" font-size="11" class="text-dim">Modular, corpus-preferring RAG stack</text>
+  <text x="600" y="28" text-anchor="middle" font-size="20" font-weight="bold" class="text">rag-suite architecture</text>
+  <text x="600" y="46" text-anchor="middle" font-size="11" class="text-dim">April 2026 — Modular corpus-preferring RAG stack</text>
 
-  <!-- ════════════════════════════════════════════════════════ -->
-  <!-- Document sources (top) -->
-  <!-- ════════════════════════════════════════════════════════ -->
-  <rect x="280" y="64" width="400" height="44" rx="6" class="box-external"/>
-  <text x="480" y="82" text-anchor="middle" font-weight="600" class="text">Document sources</text>
-  <text x="373" y="98" text-anchor="middle" font-size="10" class="text-dim">Google Drive</text>
-  <text x="480" y="98" text-anchor="middle" font-size="10" class="text-dim">git repos</text>
-  <text x="580" y="98" text-anchor="middle" font-size="10" class="text-dim">web URLs</text>
-
-  <!-- ════════════════════════════════════════════════════════ -->
-  <!-- ragstuffer -->
-  <!-- ════════════════════════════════════════════════════════ -->
-  <line x1="480" y1="108" x2="480" y2="126" class="arrow-green" stroke-width="2" marker-end="url(#ahg)"/>
-
-  <rect x="340" y="130" width="280" height="80" rx="6" class="box-ragstuffer" stroke-width="2"/>
-  <text x="480" y="152" text-anchor="middle" font-weight="700" font-size="14" class="text-green">ragstuffer</text>
-  <text x="480" y="170" text-anchor="middle" font-size="10" class="text-dim">extract text from PDF, DOCX, PPTX, XLSX, HTML, MD</text>
-  <text x="480" y="184" text-anchor="middle" font-size="10" class="text-dim">chunk (1024/128 overlap) + embed (bge-base-en-v1.5)</text>
-  <text x="480" y="198" text-anchor="middle" font-size="10" class="text-dim">deterministic UUID5 keying + incremental updates</text>
-
-  <!-- ════════════════════════════════════════════════════════ -->
-  <!-- Data stores -->
-  <!-- ════════════════════════════════════════════════════════ -->
-  <!-- ragstuffer → Postgres -->
-  <line x1="400" y1="210" x2="250" y2="260" class="arrow-green" stroke-width="1.5" marker-end="url(#ahg)"/>
-  <text x="300" y="232" text-anchor="middle" font-size="9" class="text-dim">chunks</text>
-
-  <!-- ragstuffer → Qdrant -->
-  <line x1="560" y1="210" x2="710" y2="260" class="arrow-green" stroke-width="1.5" marker-end="url(#ahg)"/>
-  <text x="660" y="232" text-anchor="middle" font-size="9" class="text-dim">vectors + refs</text>
-
-  <rect x="130" y="264" width="200" height="56" rx="6" class="box-store"/>
-  <text x="230" y="287" text-anchor="middle" font-weight="600" font-size="12" class="text">PostgreSQL</text>
-  <text x="230" y="307" text-anchor="middle" font-size="10" class="text-dim">full chunk text + metadata</text>
-
-  <rect x="630" y="264" width="200" height="56" rx="6" class="box-store"/>
-  <text x="730" y="287" text-anchor="middle" font-weight="600" font-size="12" class="text">Qdrant</text>
-  <text x="730" y="307" text-anchor="middle" font-size="10" class="text-dim">vectors + reference payloads</text>
-
-  <!-- ════════════════════════════════════════════════════════ -->
-  <!-- Request flow (middle) -->
-  <!-- ════════════════════════════════════════════════════════ -->
-
-  <!-- Client -->
-  <rect x="30" y="380" width="120" height="44" rx="6" class="box-external"/>
-  <text x="90" y="400" text-anchor="middle" font-weight="600" font-size="12" class="text">Client</text>
-  <text x="90" y="414" text-anchor="middle" font-size="9" class="text-dim">Open WebUI / SDK</text>
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- CLIENT LAYER (top) -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <rect x="460" y="62" width="280" height="44" rx="6" class="box-client"/>
+  <text x="600" y="82" text-anchor="middle" font-weight="700" font-size="14" class="text-client">Open WebUI</text>
+  <text x="600" y="97" text-anchor="middle" font-size="10" class="text-dim">:3000</text>
 
   <!-- Client → LiteLLM -->
-  <line x1="150" y1="402" x2="190" y2="402" class="arrow-dim" stroke-width="1.5" marker-end="url(#ahd)"/>
+  <line x1="600" y1="106" x2="600" y2="130" class="arrow-client" stroke-width="2" marker-end="url(#ac)"/>
+  <rect x="520" y="112" width="80" height="16" class="label-bg" rx="3"/>
+  <text x="560" y="124" text-anchor="middle" font-size="9" class="text-dim">queries</text>
 
-  <!-- LiteLLM -->
-  <rect x="195" y="380" width="110" height="44" rx="6" class="box-external"/>
-  <text x="250" y="400" text-anchor="middle" font-weight="600" font-size="12" class="text">LiteLLM</text>
-  <text x="250" y="414" text-anchor="middle" font-size="9" class="text-dim">:4000</text>
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- LITE LLM PROXY -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <rect x="490" y="134" width="220" height="44" rx="6" class="box-client"/>
+  <text x="600" y="154" text-anchor="middle" font-weight="700" font-size="14" class="text-client">LiteLLM</text>
+  <text x="600" y="169" text-anchor="middle" font-size="10" class="text-dim">:4000 — OpenAI-compatible proxy</text>
 
   <!-- LiteLLM → ragpipe -->
-  <line x1="305" y1="402" x2="345" y2="402" class="arrow" stroke-width="2" marker-end="url(#ah)"/>
+  <line x1="600" y1="178" x2="600" y2="202" class="arrow-inference" stroke-width="2" marker-end="url(#aii)"/>
+  <rect x="520" y="184" width="80" height="16" class="label-bg" rx="3"/>
+  <text x="560" y="196" text-anchor="middle" font-size="9" class="text-dim">queries</text>
 
-  <!-- ragpipe -->
-  <rect x="350" y="350" width="280" height="104" rx="6" class="box-ragpipe" stroke-width="2"/>
-  <text x="490" y="374" text-anchor="middle" font-weight="700" font-size="14" class="text-accent">ragpipe</text>
-  <text x="490" y="392" text-anchor="middle" font-size="10" class="text-dim">classify query + select route</text>
-  <text x="490" y="406" text-anchor="middle" font-size="10" class="text-dim">search Qdrant + hydrate from Postgres</text>
-  <text x="490" y="420" text-anchor="middle" font-size="10" class="text-dim">rerank (cross-encoder) + inject context</text>
-  <text x="490" y="434" text-anchor="middle" font-size="10" class="text-dim">validate citations + classify grounding</text>
-  <text x="490" y="448" text-anchor="middle" font-size="10" class="text-dim">audit log (text-free)</text>
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- INFERENCE LAYER — ragpipe (center) -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <rect x="380" y="206" width="440" height="140" rx="8" class="box-inference"/>
+  <text x="600" y="228" text-anchor="middle" font-weight="700" font-size="15" class="text-inference">ragpipe</text>
+  <text x="600" y="244" text-anchor="middle" font-size="10" class="text-dim">:8090 — Semantic router, RAG pipeline, citation validation</text>
 
-  <!-- ragpipe → Qdrant -->
-  <line x1="610" y1="380" x2="730" y2="320" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
-  <text x="690" y="342" text-anchor="middle" font-size="9" class="text-dim">search</text>
+  <!-- Semantic router inside ragpipe -->
+  <rect x="520" y="252" width="160" height="44" rx="4" fill="none" stroke="#4dff88" stroke-dasharray="4,2" stroke-width="1"/>
+  <text x="600" y="268" text-anchor="middle" font-size="10" class="text-inference">Semantic Router</text>
+  <text x="600" y="282" text-anchor="middle" font-size="9" class="text-dim">classify → select collection</text>
 
-  <!-- ragpipe → Postgres -->
-  <line x1="370" y1="380" x2="270" y2="320" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
-  <text x="295" y="342" text-anchor="middle" font-size="9" class="text-dim">hydrate</text>
+  <!-- ragpipe internal flows -->
+  <line x1="600" y1="296" x2="600" y2="316" class="arrow-inference" stroke-width="1.5" marker-end="url(#aii)"/>
+  <line x1="560" y1="320" x2="420" y2="360" class="arrow-storage" stroke-width="1.5" marker-end="url(#as)"/>
+  <line x1="640" y1="320" x2="780" y2="360" class="arrow-storage" stroke-width="1.5" marker-end="url(#as)"/>
 
-  <!-- ragpipe → Model -->
-  <line x1="630" y1="402" x2="690" y2="402" class="arrow-dim" stroke-width="2" marker-end="url(#ahd)"/>
+  <rect x="520" y="300" width="80" height="16" class="label-bg" rx="3"/>
+  <text x="560" y="312" text-anchor="middle" font-size="9" class="text-dim">hydrate</text>
+  <rect x="700" y="340" width="60" height="16" class="label-bg" rx="3"/>
+  <text x="730" y="352" text-anchor="middle" font-size="9" class="text-dim">search</text>
 
-  <!-- Model -->
-  <rect x="695" y="380" width="140" height="44" rx="6" class="box-external"/>
-  <text x="765" y="400" text-anchor="middle" font-weight="600" font-size="12" class="text">LLM</text>
-  <text x="765" y="414" text-anchor="middle" font-size="9" class="text-dim">ramalama :8080</text>
+  <!-- ragpipe → LLM -->
+  <line x1="820" y1="276" x2="880" y2="276" class="arrow-inference" stroke-width="2" marker-end="url(#aii)"/>
+  <rect x="840" y="260" width="80" height="16" class="label-bg" rx="3"/>
+  <text x="880" y="272" text-anchor="middle" font-size="9" class="text-dim">grounded query</text>
 
-  <!-- Response path (dashed, back to client) -->
-  <line x1="765" y1="424" x2="765" y2="488" class="arrow-dim" stroke-width="1" stroke-dasharray="4,2"/>
-  <line x1="765" y1="488" x2="90" y2="488" class="arrow-dim" stroke-width="1" stroke-dasharray="4,2" marker-end="url(#ahd)"/>
-  <text x="430" y="500" text-anchor="middle" font-size="9" class="text-dim">response + rag_metadata (grounding: corpus / general / mixed)</text>
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- STORAGE LAYER -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
 
-  <!-- ════════════════════════════════════════════════════════ -->
-  <!-- ragprobe (bottom left) -->
-  <!-- ════════════════════════════════════════════════════════ -->
-  <rect x="30" y="520" width="240" height="56" rx="6" class="box-ragprobe" stroke-width="2"/>
-  <text x="150" y="544" text-anchor="middle" font-weight="700" font-size="14" class="text-pink">ragprobe</text>
-  <text x="150" y="560" text-anchor="middle" font-size="10" class="text-dim">66+ adversarial tests across 13 categories</text>
+  <!-- Qdrant -->
+  <rect x="800" y="364" width="200" height="90" rx="6" class="box-storage"/>
+  <text x="900" y="386" text-anchor="middle" font-weight="700" font-size="13" class="text-storage">Qdrant</text>
+  <text x="900" y="402" text-anchor="middle" font-size="10" class="text-dim">:6333</text>
+  <text x="900" y="418" text-anchor="middle" font-size="9" class="text-dim">Collections:</text>
+  <text x="900" y="432" text-anchor="middle" font-size="9" class="text-dim">personnel | nato | mpep | documents</text>
+  <text x="900" y="446" text-anchor="middle" font-size="9" class="text-dim">vectors + reference payloads</text>
 
-  <!-- ragprobe → ragpipe -->
-  <line x1="270" y1="530" x2="440" y2="454" class="arrow-pink" stroke-width="1.5" marker-end="url(#ahp)"/>
-  <text x="370" y="502" text-anchor="middle" font-size="9" class="text-pink">adversarial eval</text>
+  <!-- Postgres -->
+  <rect x="360" y="364" width="200" height="90" rx="6" class="box-storage"/>
+  <text x="460" y="386" text-anchor="middle" font-weight="700" font-size="13" class="text-storage">Postgres</text>
+  <text x="460" y="402" text-anchor="middle" font-size="10" class="text-dim">:5432</text>
+  <text x="460" y="418" text-anchor="middle" font-size="9" class="text-dim">Tables:</text>
+  <text x="460" y="432" text-anchor="middle" font-size="9" class="text-dim">chunks | collections | query_log</text>
+  <text x="460" y="446" text-anchor="middle" font-size="9" class="text-dim">chunks + titles (full text)</text>
 
-  <!-- ════════════════════════════════════════════════════════ -->
-  <!-- ragwatch (bottom center) -->
-  <!-- ════════════════════════════════════════════════════════ -->
-  <rect x="290" y="520" width="200" height="56" rx="6" class="box-ragwatch" stroke-width="2"/>
-  <text x="390" y="544" text-anchor="middle" font-weight="700" font-size="14" class="text-orange">ragwatch</text>
-  <text x="390" y="560" text-anchor="middle" font-size="10" class="text-dim">Prometheus + Grafana metrics</text>
+  <!-- Query log partitioning annotation -->
+  <rect x="380" y="458" width="160" height="18" class="label-bg" rx="3"/>
+  <text x="460" y="471" text-anchor="middle" font-size="8" class="text-dim">query_log partitioned by day</text>
 
-  <!-- ragwatch → ragpipe (metrics scrape) -->
-  <line x1="400" y1="520" x2="460" y2="454" class="arrow-orange" stroke-width="1" stroke-dasharray="4,2" marker-end="url(#aho)"/>
-  <text x="445" y="492" text-anchor="middle" font-size="8" class="text-orange">metrics</text>
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- LLM -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <rect x="884" y="240" width="140" height="72" rx="6" class="box-client"/>
+  <text x="954" y="262" text-anchor="middle" font-weight="700" font-size="13" class="text-client">ramalama</text>
+  <text x="954" y="278" text-anchor="middle" font-size="10" class="text-dim">:8080 — Qwen3.5-35B</text>
+  <text x="954" y="294" text-anchor="middle" font-size="9" class="text-dim">MIGraphX / ROCm 7.x</text>
+  <text x="954" y="306" text-anchor="middle" font-size="9" class="text-dim">gfx1151 — ~3 min startup</text>
 
-  <!-- ragwatch → Grafana -->
-  <line x1="390" y1="576" x2="390" y2="610" class="arrow-orange" stroke-width="1.5" marker-end="url(#aho)"/>
-  <text x="340" y="596" text-anchor="middle" font-size="9" class="text-orange">dashboards</text>
+  <!-- Response path -->
+  <line x1="954" y1="312" x2="954" y2="500" class="arrow-client" stroke-width="1" stroke-dasharray="4,2"/>
+  <line x1="954" y1="500" x2="600" y2="500" class="arrow-client" stroke-width="1" stroke-dasharray="4,2"/>
+  <line x1="600" y1="500" x2="600" y2="640" class="arrow-client" stroke-width="1" stroke-dasharray="4,2" marker-end="url(#ac)"/>
+  <rect x="700" y="490" width="120" height="16" class="label-bg" rx="3"/>
+  <text x="760" y="502" text-anchor="middle" font-size="9" class="text-dim">response + rag_metadata</text>
 
-  <!-- Grafana -->
-  <rect x="290" y="614" width="200" height="44" rx="6" class="box-store"/>
-  <text x="390" y="640" text-anchor="middle" font-weight="600" font-size="12" class="text">Grafana</text>
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- INGESTION LAYER — ragstuffer -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <rect x="380" y="530" width="440" height="100" rx="8" class="box-ingestion"/>
+  <text x="600" y="552" text-anchor="middle" font-weight="700" font-size="15" class="text-ingestion">ragstuffer</text>
+  <text x="600" y="568" text-anchor="middle" font-size="10" class="text-dim">:8091 — Document ingestion, polls Drive / git / web</text>
 
-  <!-- ════════════════════════════════════════════════════════ -->
-  <!-- ragdeck (bottom right) -->
-  <!-- ════════════════════════════════════════════════════════ -->
-  <rect x="510" y="520" width="200" height="56" rx="6" class="box-ragdeck" stroke-width="2"/>
-  <text x="610" y="544" text-anchor="middle" font-weight="700" font-size="14" class="text-teal">ragdeck</text>
-  <text x="610" y="560" text-anchor="middle" font-size="10" class="text-dim">Admin UI — single-pane management</text>
+  <!-- Source icons -->
+  <text x="420" y="586" font-size="9" class="text-dim">Google Drive</text>
+  <text x="500" y="586" font-size="9" class="text-dim">|</text>
+  <text x="520" y="586" font-size="9" class="text-dim">git repos</text>
+  <text x="590" y="586" font-size="9" class="text-dim">|</text>
+  <text x="620" y="586" font-size="9" class="text-dim">web URLs</text>
 
-  <!-- ragdeck → ragpipe -->
-  <line x1="520" y1="520" x2="540" y2="454" class="arrow-teal" stroke-width="1" stroke-dasharray="4,2" marker-end="url(#aht)"/>
-  <text x="545" y="492" text-anchor="middle" font-size="8" class="text-teal">manage</text>
+  <!-- Title extraction badge -->
+  <rect x="680" y="574" width="120" height="18" rx="4" fill="none" stroke="#4da6ff" stroke-width="1"/>
+  <text x="740" y="587" text-anchor="middle" font-size="9" class="text-ingestion">+ title extraction</text>
 
-  <!-- ragdeck → Qdrant -->
-  <line x1="660" y1="520" x2="730" y2="320" class="arrow-teal" stroke-width="1" stroke-dasharray="4,2" marker-end="url(#aht)"/>
-  <text x="710" y="420" text-anchor="middle" font-size="8" class="text-teal">collections</text>
+  <!-- ragstuffer outputs -->
+  <line x1="460" y1="574" x2="460" y2="630" class="arrow-ingestion" stroke-width="1.5" marker-end="url(#ai)"/>
+  <line x1="600" y1="574" x2="600" y2="630" class="arrow-ingestion" stroke-width="1.5" marker-end="url(#ai)"/>
+  <line x1="740" y1="574" x2="740" y2="630" class="arrow-ingestion" stroke-width="1.5" marker-end="url(#ai)"/>
 
-  <!-- ════════════════════════════════════════════════════════ -->
-  <!-- framework-ai-stack (far bottom right) -->
-  <!-- ════════════════════════════════════════════════════════ -->
-  <rect x="730" y="520" width="200" height="56" rx="6" class="box-stack" stroke-width="2"/>
-  <text x="830" y="544" text-anchor="middle" font-weight="700" font-size="13" class="text-yellow">framework-ai-stack</text>
-  <text x="830" y="560" text-anchor="middle" font-size="10" class="text-dim">reference deployment</text>
+  <rect x="400" y="614" width="60" height="14" class="label-bg" rx="3"/>
+  <text x="430" y="624" text-anchor="middle" font-size="8" class="text-dim">chunks+titles</text>
+  <rect x="570" y="614" width="60" height="14" class="label-bg" rx="3"/>
+  <text x="600" y="624" text-anchor="middle" font-size="8" class="text-dim">vectors</text>
+  <rect x="710" y="614" width="60" height="14" class="label-bg" rx="3"/>
+  <text x="740" y="624" text-anchor="middle" font-size="8" class="text-dim">metadata</text>
 
-  <!-- framework-ai-stack dashed region indicator -->
-  <rect x="20" y="250" width="920" height="210" rx="8" class="region"/>
-  <text x="920" y="266" text-anchor="end" font-size="9" class="text-dim">deployed by framework-ai-stack</text>
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- OBSERVABILITY — ragwatch -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <rect x="900" y="530" width="180" height="100" rx="8" class="box-observability"/>
+  <text x="990" y="552" text-anchor="middle" font-weight="700" font-size="15" class="text-observability">ragwatch</text>
+  <text x="990" y="568" text-anchor="middle" font-size="10" class="text-dim">:9090 — Prometheus aggregation</text>
+  <text x="990" y="584" text-anchor="middle" font-size="9" class="text-dim">/metrics</text>
+  <text x="990" y="596" text-anchor="middle" font-size="9" class="text-dim">/metrics/summary (JSON)</text>
+  <text x="990" y="614" text-anchor="middle" font-size="9" class="text-dim">scrape interval: 30s</text>
+
+  <!-- ragwatch scrape connections -->
+  <line x1="900" y1="570" x2="820" y2="300" class="arrow-observability" stroke-width="1" stroke-dasharray="4,2"/>
+  <line x1="900" y1="590" x2="820" y2="630" class="arrow-observability" stroke-width="1" stroke-dasharray="4,2"/>
+  <rect x="848" y="580" width="50" height="14" class="label-bg" rx="3"/>
+  <text x="873" y="590" text-anchor="middle" font-size="8" class="text-observability">metrics</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- ADMIN — ragdeck -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <rect x="40" y="530" width="180" height="100" rx="8" class="box-admin"/>
+  <text x="130" y="552" text-anchor="middle" font-weight="700" font-size="15" class="text-admin">ragdeck</text>
+  <text x="130" y="568" text-anchor="middle" font-size="10" class="text-dim">:8095 — Admin UI (scaffold)</text>
+  <text x="130" y="584" text-anchor="middle" font-size="9" class="text-dim">currently: /health only</text>
+  <text x="130" y="600" text-anchor="middle" font-size="9" class="text-dim">planned:</text>
+  <text x="130" y="612" text-anchor="middle" font-size="9" class="text-dim">collections | ingest | query_log</text>
+  <text x="130" y="624" text-anchor="middle" font-size="9" class="text-dim">probe runs | metrics</text>
+
+  <!-- ragdeck connections -->
+  <line x1="220" y1="560" x2="380" y2="276" class="arrow-admin" stroke-width="1" stroke-dasharray="4,2"/>
+  <line x1="220" y1="580" x2="360" y2="400" class="arrow-admin" stroke-width="1" stroke-dasharray="4,2"/>
+  <line x1="220" y1="600" x2="800" y2="400" class="arrow-admin" stroke-width="1" stroke-dasharray="4,2"/>
+  <line x1="220" y1="620" x2="900" y2="560" class="arrow-admin" stroke-width="1" stroke-dasharray="4,2"/>
+
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- DATA SOURCE — Document sources -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <rect x="440" y="680" width="320" height="50" rx="6" class="box-client"/>
+  <text x="600" y="700" text-anchor="middle" font-weight="600" class="text-client">Document Sources</text>
+  <text x="510" y="718" text-anchor="middle" font-size="9" class="text-dim">Google Drive</text>
+  <text x="600" y="718" text-anchor="middle" font-size="9" class="text-dim">|</text>
+  <text x="640" y="718" text-anchor="middle" font-size="9" class="text-dim">git repos</text>
+  <text x="690" y="718" text-anchor="middle" font-size="9" class="text-dim">|</text>
+  <text x="720" y="718" text-anchor="middle" font-size="9" class="text-dim">web URLs</text>
+
+  <!-- Document sources → ragstuffer -->
+  <line x1="600" y1="680" x2="600" y2="630" class="arrow-ingestion" stroke-width="2" marker-end="url(#ai)"/>
+  <rect x="540" y="658" width="120" height="16" class="label-bg" rx="3"/>
+  <text x="600" y="670" text-anchor="middle" font-size="9" class="text-dim">poll + download</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- LEGEND -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <rect x="40" y="60" width="220" height="160" rx="6" class="legend-bg" stroke-width="1"/>
+  <text x="60" y="80" font-weight="700" font-size="11" class="text">Legend</text>
+
+  <!-- Ingestion -->
+  <rect x="50" y="90" width="16" height="16" rx="2" class="box-ingestion"/>
+  <text x="72" y="103" font-size="10" class="text-ingestion">Ingestion</text>
+
+  <!-- Inference -->
+  <rect x="50" y="112" width="16" height="16" rx="2" class="box-inference"/>
+  <text x="72" y="125" font-size="10" class="text-inference">Inference</text>
+
+  <!-- Storage -->
+  <rect x="50" y="134" width="16" height="16" rx="2" class="box-storage"/>
+  <text x="72" y="147" font-size="10" class="text-storage">Storage</text>
+
+  <!-- Observability -->
+  <rect x="50" y="156" width="16" height="16" rx="2" class="box-observability"/>
+  <text x="72" y="169" font-size="10" class="text-observability">Observability</text>
+
+  <!-- Admin -->
+  <rect x="50" y="178" width="16" height="16" rx="2" class="box-admin"/>
+  <text x="72" y="191" font-size="10" class="text-admin">Admin UI</text>
+
+  <!-- Client -->
+  <rect x="50" y="200" width="16" height="16" rx="2" class="box-client"/>
+  <text x="72" y="213" font-size="10" class="text-client">Client</text>
+
+  <!-- Arrow legend -->
+  <line x1="150" y1="100" x2="200" y2="100" class="arrow-inference" stroke-width="2" marker-end="url(#aii)"/>
+  <text x="225" y="104" font-size="9" class="text-dim">Query</text>
+
+  <line x1="150" y1="120" x2="200" y2="120" class="arrow-storage" stroke-width="2" marker-end="url(#as)"/>
+  <text x="225" y="124" font-size="9" class="text-dim">Vector/Chunk</text>
+
+  <line x1="150" y1="140" x2="200" y2="140" class="arrow-client" stroke-width="1" stroke-dasharray="4,2"/>
+  <text x="225" y="144" font-size="9" class="text-dim">Response</text>
+
+  <line x1="150" y1="160" x2="200" y2="160" class="arrow-observability" stroke-width="1" stroke-dasharray="4,2"/>
+  <text x="225" y="164" font-size="9" class="text-dim">Metrics</text>
+
+  <line x1="150" y1="180" x2="200" y2="180" class="arrow-admin" stroke-width="1" stroke-dasharray="4,2"/>
+  <text x="225" y="184" font-size="9" class="text-dim">Manage</text>
 
   <!-- Footer -->
-  <text x="480" y="727" text-anchor="middle" font-size="10" class="text-dim">github.com/aclater/rag-suite</text>
+  <text x="600" y="765" text-anchor="middle" font-size="10" class="text-dim">github.com/aclater/rag-suite | All services rootless Podman | SELinux enforcing</text>
 </svg>


### PR DESCRIPTION
Full documentation audit against current codebase and live system. Updates READMEs, CLAUDE.md files, and architecture diagram to reflect current state.

## Changes

### README.md
- Added ragprobe to component table with 66+ tests
- Added multi-collection routing architecture description
- Added query_log partitioning documentation
- Updated tech stack table with accurate versions
- Added title extraction documentation
- Added hot-reload endpoints section

### architecture.svg (new)
- Complete rewrite with all services, ports, and data flows
- Color-coded by layer: ingestion (blue), inference (green), storage (orange), observability (purple), admin (gray)
- Shows semantic router inside ragpipe
- Shows Qdrant collections: personnel, nato, mpep, documents
- Shows Postgres tables: chunks, collections, query_log
- Legend with arrow types
- Date: April 2026

### CLAUDE.md (new)
- Created with architectural overview
- Documents semantic routing, title extraction, query log partitioning