### PR TITLE
chore: add PR template for consistent descriptions (fixes #29)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Problem
+
+<!-- What was wrong or missing? Link to the issue: Closes #N -->
+
+## Solution
+
+<!-- What was changed and why? -->
+
+## Testing
+
+<!-- How was this tested? Include test counts before/after if applicable. -->
+
+## Checklist
+
+- [ ] Tests pass locally (`pytest`)
+- [ ] Linting passes (`ruff check`)
+- [ ] Type checking passes (`mypy`)
+- [ ] No secrets committed
+- [ ] Commit messages reference the issue (`fixes #N` or `refs #N`)


### PR DESCRIPTION
Closes #29

## Problem
No PR template existed across the rag-suite repos, leading to inconsistent PR descriptions.

## Solution
Added `.github/PULL_REQUEST_TEMPLATE.md` with Problem, Solution, Testing sections and a pre-merge checklist (tests, lint, types, secrets, commit messages). Matches the PR body format already used across the stack per AGENTS.md.

## Testing
Template-only change — no code to test. Verified markdown renders correctly.