### PR TITLE
feat(infrastructure): add issue templates (fixes #30)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,25 @@
+---
+name: Bug
+about: Report something that's broken
+title: "fix: <what's broken>"
+labels: type: bug,priority: medium
+assignees: ''
+---
+
+## Problem
+Describe what is broken and expected behavior.
+
+## Steps to Reproduce
+1.
+2.
+3.
+
+## Environment
+- OS:
+- Version:
+
+## Logs
+```
+```
+
+## Proposed Fix

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,20 @@
+---
+name: Feature
+about: Request new functionality
+title: "feat: <description>"
+labels: type: feature,priority: medium
+assignees: ''
+---
+
+## Context
+Why is this needed?
+
+## Requirements
+- 
+- 
+
+## Success Criteria
+- 
+- 
+
+## Related Issues

--- a/.github/ISSUE_TEMPLATE/infrastructure.md
+++ b/.github/ISSUE_TEMPLATE/infrastructure.md
@@ -1,0 +1,22 @@
+---
+name: Infrastructure
+about: Infrastructure or deployment work
+title: "infra: <description>"
+labels: type: infrastructure,priority: medium
+assignees: ''
+---
+
+## Context
+What needs to be done?
+
+## Current State
+Describe current infrastructure.
+
+## Desired State
+What should change?
+
+## Plan
+- 
+- 
+
+## Dependencies

--- a/.github/ISSUE_TEMPLATE/research.md
+++ b/.github/ISSUE_TEMPLATE/research.md
@@ -1,0 +1,28 @@
+---
+name: Research Spike
+about: Investigate and evaluate options
+title: "research: <topic>"
+labels: type: feature,priority: low
+assignees: ''
+---
+
+## Question
+What are we researching?
+
+## Background
+Context and prior work.
+
+## Research Plan
+- 
+- 
+
+## Evaluation Criteria
+- 
+- 
+
+## Options to Evaluate
+1.
+2.
+
+## Expected Output
+Document findings and recommendation.


### PR DESCRIPTION
Closes #30

## Change
Add standard GitHub issue templates for bug, feature, infrastructure, and research spike types to standardize issue creation.

## Testing
Created locally, follows GitHub issue template format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub issue templates for bug reports, feature requests, infrastructure work, and research activities. Each template includes structured sections and metadata configuration to standardize issue submission and improve project organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->