### PR TITLE
feat(migrations): add agentic columns to query_log (fixes #40)

### DIFF
--- a/migrations/007_query_log_agentic_columns.sql
+++ b/migrations/007_query_log_agentic_columns.sql
@@ -1,0 +1,14 @@
+-- 007_query_log_agentic_columns.sql
+-- Add CRAG and agentic RAG tracking columns to query_log.
+-- Safe to re-run: uses ADD COLUMN IF NOT EXISTS throughout.
+--
+-- New columns:
+--   query_rewritten    — whether CRAG triggered a query rewrite (default false)
+--   retrieval_attempts — number of retrieval passes, 1=normal, 2=CRAG retry (default 1)
+--   original_query     — the user's original query when rewrite occurred
+--   rewritten_query    — the LLM-rewritten query when rewrite occurred
+
+ALTER TABLE query_log ADD COLUMN IF NOT EXISTS query_rewritten BOOLEAN DEFAULT FALSE;
+ALTER TABLE query_log ADD COLUMN IF NOT EXISTS retrieval_attempts INTEGER DEFAULT 1;
+ALTER TABLE query_log ADD COLUMN IF NOT EXISTS original_query TEXT;
+ALTER TABLE query_log ADD COLUMN IF NOT EXISTS rewritten_query TEXT;

--- a/migrations/test_migrations.py
+++ b/migrations/test_migrations.py
@@ -427,8 +427,81 @@ def test_probe_results_insert_and_read(migrated_db):
 
 # -- Migration ordering --
 
+# -- Agentic columns (007_query_log_agentic_columns.sql) --
+
+def test_query_log_agentic_columns_exist(migrated_db):
+    """query_log should have CRAG/agentic tracking columns after migration 007."""
+    cur = migrated_db.cursor()
+    cur.execute(
+        "SELECT column_name, data_type FROM information_schema.columns "
+        "WHERE table_name = 'query_log' AND column_name IN "
+        "('query_rewritten', 'retrieval_attempts', 'original_query', 'rewritten_query') "
+        "ORDER BY column_name"
+    )
+    cols = {row[0]: row[1] for row in cur.fetchall()}
+    assert cols["query_rewritten"] == "boolean"
+    assert cols["retrieval_attempts"] == "integer"
+    assert cols["original_query"] == "text"
+    assert cols["rewritten_query"] == "text"
+
+
+def test_query_log_agentic_defaults(migrated_db):
+    """New rows should get sensible defaults for agentic columns."""
+    cur = migrated_db.cursor()
+    cur.execute(
+        "INSERT INTO query_log (query_text, query_hash, grounding, total_chunks) "
+        "VALUES (%s, %s, %s, %s) RETURNING id",
+        ("test defaults", "hash-defaults", "corpus", 5),
+    )
+    row_id = cur.fetchone()[0]
+    cur.execute(
+        "SELECT query_rewritten, retrieval_attempts, original_query, rewritten_query "
+        "FROM query_log WHERE id = %s",
+        (row_id,),
+    )
+    row = cur.fetchone()
+    assert row[0] is False  # query_rewritten default
+    assert row[1] == 1  # retrieval_attempts default
+    assert row[2] is None  # original_query nullable
+    assert row[3] is None  # rewritten_query nullable
+
+
+def test_query_log_agentic_insert_with_rewrite(migrated_db):
+    """Writing CRAG metadata to query_log should work."""
+    cur = migrated_db.cursor()
+    cur.execute(
+        "INSERT INTO query_log ("
+        "  query_text, query_hash, grounding, total_chunks, "
+        "  query_rewritten, retrieval_attempts, original_query, rewritten_query"
+        ") VALUES (%s, %s, %s, %s, %s, %s, %s, %s) RETURNING id",
+        (
+            "patent claims software",
+            "hash-crag",
+            "corpus",
+            10,
+            True,
+            2,
+            "patent claims software",
+            "What are the requirements for software patent claims under MPEP?",
+        ),
+    )
+    row_id = cur.fetchone()[0]
+    cur.execute(
+        "SELECT query_rewritten, retrieval_attempts, original_query, rewritten_query "
+        "FROM query_log WHERE id = %s",
+        (row_id,),
+    )
+    row = cur.fetchone()
+    assert row[0] is True
+    assert row[1] == 2
+    assert row[2] == "patent claims software"
+    assert "software patent claims" in row[3].lower()
+
+
+# -- Migration ordering --
+
 def test_migration_order():
-    """Migration files must exist in numeric order 001, 002, 003, 004, 005, 006."""
+    """Migration files must exist in numeric order 001 through 007."""
     files = sorted(
         f for f in os.listdir(MIGRATIONS_DIR)
         if f.endswith(".sql") and f[0].isdigit()
@@ -440,4 +513,5 @@ def test_migration_order():
         "004_collections_source_types.sql",
         "005_chunks_created_at_timestamptz.sql",
         "006_ragas_probe_results.sql",
+        "007_query_log_agentic_columns.sql",
     ]


### PR DESCRIPTION
Closes #40

## Problem
ragdeck `/agentic/stats` returned "unavailable" because `query_log` lacked columns for CRAG and agentic behavior tracking.

## Solution
Added `migrations/007_query_log_agentic_columns.sql` with four new columns:
- `query_rewritten BOOLEAN DEFAULT FALSE`
- `retrieval_attempts INTEGER DEFAULT 1`
- `original_query TEXT`
- `rewritten_query TEXT`

All columns use `ADD COLUMN IF NOT EXISTS` for idempotency. Nullable or defaulted so existing rows are unaffected.

## Testing
- 27/27 migration tests pass against live Postgres
- Migration verified idempotent (re-run produces NOTICEs, no errors)
- Columns confirmed with correct types and defaults:
  ```
  column_name        | data_type | column_default
  query_rewritten    | boolean   | false
  retrieval_attempts | integer   | 1
  original_query     | text      |
  rewritten_query    | text      |
  ```

## Note
ragdeck `/agentic/stats` still returns "unavailable" because it also requires agentic data in the columns (populated by ragpipe after #62 is deployed). The schema is ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)